### PR TITLE
Add simple RL placement example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# PCN_Placement
+# PCN Placement
+
+This repository contains utilities for experimenting with placement algorithms.
+
+## New RL Example
+
+The `layout_rl` directory demonstrates a minimal reinforcement learning setup for
+component placement. A simple grid based environment is provided together with a
+small PPO implementation. To run a quick training session execute:
+
+```bash
+python -m layout_rl.train
+```
+
+The environment and agent are intentionally lightweight so they can run without
+extra dependencies.

--- a/layout_rl/ppo_agent.py
+++ b/layout_rl/ppo_agent.py
@@ -1,0 +1,122 @@
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.distributions import Categorical
+
+class ActorCritic(nn.Module):
+    def __init__(self, state_dim, action_dim, hidden_dim=128):
+        super().__init__()
+        self.base = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.ReLU(),
+        )
+        self.actor = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, action_dim),
+            nn.Softmax(dim=-1),
+        )
+        self.critic = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, x):
+        x = self.base(x)
+        probs = self.actor(x)
+        value = self.critic(x)
+        return probs, value
+
+class PPOAgent:
+    def __init__(self, env, lr=3e-4, gamma=0.99, clip_eps=0.2, k_epochs=4, gae_lambda=0.95, ent_coef=0.01):
+        self.env = env
+        state_dim = np.prod(env.observation_space.shape)
+        action_dim = env.action_space.n
+        self.gamma = gamma
+        self.clip_eps = clip_eps
+        self.k_epochs = k_epochs
+        self.gae_lambda = gae_lambda
+        self.ent_coef = ent_coef
+
+        self.policy = ActorCritic(state_dim, action_dim)
+        self.optimizer = optim.Adam(self.policy.parameters(), lr=lr)
+
+    def select_action(self, state):
+        state_tensor = torch.FloatTensor(state.flatten()).unsqueeze(0)
+        probs, value = self.policy(state_tensor)
+        dist = Categorical(probs)
+        action = dist.sample()
+        return action.item(), dist.log_prob(action), value.squeeze(0), dist.entropy()
+
+    def compute_gae(self, rewards, values, dones):
+        advantages = []
+        gae = 0
+        values = values + [0]
+        for i in reversed(range(len(rewards))):
+            delta = rewards[i] + self.gamma * values[i + 1] * (1 - dones[i]) - values[i]
+            gae = delta + self.gamma * self.gae_lambda * (1 - dones[i]) * gae
+            advantages.insert(0, gae)
+        return advantages
+
+    def update(self, memory):
+        states = torch.FloatTensor(np.array(memory['states'])).reshape(len(memory['states']), -1)
+        actions = torch.LongTensor(memory['actions']).unsqueeze(-1)
+        old_logps = torch.stack(memory['log_probs']).unsqueeze(-1)
+        returns = torch.FloatTensor(memory['returns']).unsqueeze(-1)
+        advantages = torch.FloatTensor(memory['advantages']).unsqueeze(-1)
+
+        for _ in range(self.k_epochs):
+            probs, values = self.policy(states)
+            dist = Categorical(probs)
+            new_logps = dist.log_prob(actions.squeeze(-1)).unsqueeze(-1)
+            entropy = dist.entropy().mean()
+
+            ratios = torch.exp(new_logps - old_logps)
+            surr1 = ratios * advantages
+            surr2 = torch.clamp(ratios, 1 - self.clip_eps, 1 + self.clip_eps) * advantages
+            actor_loss = -torch.min(surr1, surr2).mean()
+            critic_loss = nn.MSELoss()(values, returns)
+            loss = actor_loss + 0.5 * critic_loss - self.ent_coef * entropy
+
+            self.optimizer.zero_grad()
+            loss.backward()
+            self.optimizer.step()
+
+    def train(self, max_episodes=1000, update_timestep=200):
+        timestep = 0
+        memory = {k: [] for k in ['states', 'actions', 'log_probs', 'rewards', 'dones', 'values']}
+        for episode in range(max_episodes):
+            state = self.env.reset()
+            done = False
+            ep_reward = 0
+            while not done:
+                action, logp, value, _ = self.select_action(state)
+                next_state, reward, done, _ = self.env.step(action)
+                memory['states'].append(state)
+                memory['actions'].append(action)
+                memory['log_probs'].append(logp)
+                memory['values'].append(value.item())
+                memory['rewards'].append(reward)
+                memory['dones'].append(done)
+                state = next_state
+                ep_reward += reward
+                timestep += 1
+                if timestep % update_timestep == 0 or done:
+                    returns = []
+                    discounted = 0
+                    for r, d in zip(reversed(memory['rewards']), reversed(memory['dones'])):
+                        if d:
+                            discounted = 0
+                        discounted = r + self.gamma * discounted
+                        returns.insert(0, discounted)
+                    advantages = self.compute_gae(memory['rewards'], memory['values'], memory['dones'])
+                    memory['returns'] = returns
+                    memory['advantages'] = advantages
+                    self.update(memory)
+                    for k in memory:
+                        memory[k] = []
+                    timestep = 0
+            if (episode + 1) % 10 == 0:
+                print(f"Episode {episode+1}, reward: {ep_reward:.2f}")

--- a/layout_rl/simple_placement_env.py
+++ b/layout_rl/simple_placement_env.py
@@ -1,0 +1,77 @@
+import numpy as np
+import gym
+from gym import spaces
+
+class SimplePlacementEnv(gym.Env):
+    """A simple grid based placement environment."""
+
+    def __init__(self, area_size=(10, 10), components=None, connections=None):
+        super().__init__()
+        self.area_height, self.area_width = area_size
+        # components is list of (height, width)
+        if components is None:
+            components = [(2, 2), (3, 1), (1, 3)]
+        self.components = components
+        self.num_components = len(components)
+        self.connections = connections or []  # list of (idx_a, idx_b)
+
+        # observation is an integer grid representing placed component index+1
+        self.observation_space = spaces.Box(low=0, high=self.num_components,
+                                            shape=(self.area_height, self.area_width),
+                                            dtype=np.int32)
+        # action is choosing a grid cell to place current component
+        self.action_space = spaces.Discrete(self.area_height * self.area_width)
+        self.reset()
+
+    def reset(self):
+        self.grid = np.zeros((self.area_height, self.area_width), dtype=np.int32)
+        self.current = 0  # index of component to place
+        return self.grid.copy()
+
+    def _can_place(self, y, x, shape):
+        h, w = shape
+        if y + h > self.area_height or x + w > self.area_width:
+            return False
+        sub = self.grid[y:y+h, x:x+w]
+        return np.all(sub == 0)
+
+    def _place(self, y, x, shape):
+        h, w = shape
+        self.grid[y:y+h, x:x+w] = self.current + 1
+
+    def step(self, action):
+        y = action // self.area_width
+        x = action % self.area_width
+        shape = self.components[self.current]
+        reward = -1.0
+        done = False
+
+        if self._can_place(y, x, shape):
+            self._place(y, x, shape)
+            reward = 0.0
+            self.current += 1
+            if self.current == self.num_components:
+                reward = -self._total_connection_length()
+                done = True
+        else:
+            # invalid placement
+            reward = -5.0
+
+        return self.grid.copy(), reward, done, {}
+
+    def _centroid(self, component_idx):
+        loc = np.argwhere(self.grid == component_idx + 1)
+        if loc.size == 0:
+            return None
+        y_min, x_min = loc.min(axis=0)
+        y_max, x_max = loc.max(axis=0)
+        return np.array([(y_min + y_max) / 2, (x_min + x_max) / 2])
+
+    def _total_connection_length(self):
+        total = 0.0
+        for a, b in self.connections:
+            ca = self._centroid(a)
+            cb = self._centroid(b)
+            if ca is not None and cb is not None:
+                total += np.abs(ca - cb).sum()
+        return total

--- a/layout_rl/train.py
+++ b/layout_rl/train.py
@@ -1,0 +1,14 @@
+from .simple_placement_env import SimplePlacementEnv
+from .ppo_agent import PPOAgent
+
+
+def main():
+    components = [(2, 2), (3, 1), (1, 3)]
+    connections = [(0, 1), (1, 2), (0, 2)]
+    env = SimplePlacementEnv(area_size=(8, 8), components=components, connections=connections)
+    agent = PPOAgent(env)
+    agent.train(max_episodes=200)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- tidy README with a usage note
- add `layout_rl` example package
- provide a minimal grid placement environment
- implement a lightweight PPO agent
- supply a training entrypoint

## Testing
- `python -m py_compile layout_rl/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6854d6056b1c832a8dea5353ee6c103a